### PR TITLE
Add schedule webpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # open-sauce
+
 Esse arquivo explica a Open Sauce
+
+## GitHub Pages
+
+The `docs/` directory contains a simple webpage that presents the event schedule in a Nintendo-inspired style. The page reads `agenda.json` dynamically and also allows downloading the entire schedule as an ICS calendar.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Open Sauce Schedule</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Open Sauce 2025 Schedule</h1>
+        <button id="download-ics">Download ICS</button>
+    </header>
+    <main id="schedule"></main>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,0 +1,104 @@
+async function fetchSchedule() {
+    const response = await fetch('../agenda.json');
+    if (!response.ok) {
+        console.error('Failed to load agenda.json');
+        return null;
+    }
+    return await response.json();
+}
+
+function createEventElement(event) {
+    const div = document.createElement('div');
+    div.className = 'event';
+    const time = document.createElement('div');
+    time.className = 'time';
+    time.textContent = event.time;
+    const title = document.createElement('div');
+    title.textContent = event.title;
+    const where = document.createElement('div');
+    where.textContent = event.where;
+    div.append(time, title, where);
+    return div;
+}
+
+function renderSchedule(data) {
+    const schedule = document.getElementById('schedule');
+    ['friday', 'saturday', 'sunday'].forEach((day, index) => {
+        const daySection = document.createElement('section');
+        daySection.className = 'day';
+        const heading = document.createElement('h2');
+        const date = ['July 25, 2025', 'July 26, 2025', 'July 27, 2025'][index];
+        heading.textContent = day.charAt(0).toUpperCase() + day.slice(1) + ' - ' + date;
+        daySection.appendChild(heading);
+        data[day].forEach(ev => {
+            daySection.appendChild(createEventElement(ev));
+        });
+        schedule.appendChild(daySection);
+    });
+}
+
+function pad(n) { return n < 10 ? '0' + n : '' + n; }
+
+function convertTo24(timeStr) {
+    const [time, ampm] = timeStr.split(' ');
+    let [h, m] = time.split(':').map(Number);
+    if (ampm.toLowerCase() === 'pm' && h !== 12) h += 12;
+    if (ampm.toLowerCase() === 'am' && h === 12) h = 0;
+    return pad(h) + pad(m) + '00';
+}
+
+function addMinutes(timeStr, minutes) {
+    const dt = new Date('1970-01-01T' + timeStr.slice(0,2) + ':' + timeStr.slice(2,4) + ':00');
+    dt.setMinutes(dt.getMinutes() + minutes);
+    return pad(dt.getHours()) + pad(dt.getMinutes()) + '00';
+}
+
+function generateICS(data) {
+    const lines = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//Open Sauce//Schedule//EN',
+        'CALSCALE:GREGORIAN'
+    ];
+    const days = ['20250725', '20250726', '20250727'];
+    ['friday','saturday','sunday'].forEach((day, index) => {
+        data[day].forEach(ev => {
+            const start = convertTo24(ev.time);
+            const end = addMinutes(start, parseInt(ev.length || '30'));
+            lines.push('BEGIN:VEVENT');
+            lines.push('UID:' + btoa(ev.title + start));
+            lines.push('SUMMARY:' + ev.title);
+            lines.push('DTSTART;TZID=America/Los_Angeles:' + days[index] + 'T' + start);
+            lines.push('DTEND;TZID=America/Los_Angeles:' + days[index] + 'T' + end);
+            if (ev.where) lines.push('LOCATION:' + ev.where);
+            if (ev.description) lines.push('DESCRIPTION:' + ev.description.replace(/\n/g,'\\n'));
+            lines.push('END:VEVENT');
+        });
+    });
+    lines.push('END:VCALENDAR');
+    return lines.join('\r\n');
+}
+
+function setupICSButton(data) {
+    const btn = document.getElementById('download-ics');
+    btn.addEventListener('click', () => {
+        const ics = generateICS(data);
+        const blob = new Blob([ics], { type: 'text/calendar' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'schedule.ics';
+        a.style.display = 'none';
+        document.body.appendChild(a);
+        a.click();
+        URL.revokeObjectURL(url);
+        a.remove();
+    });
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+    const data = await fetchSchedule();
+    if (!data) return;
+    renderSchedule(data);
+    setupICSButton(data);
+});

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,50 @@
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    margin: 0;
+    background: #f8f8f8 url('https://assets.nintendo.com/image/upload/f_auto/q_auto/dpr_auto/ncom/en_US/switch/system-update/icon_background_pattern') repeat;
+    color: #333;
+}
+header {
+    background: #e60012;
+    color: #fff;
+    padding: 1rem;
+    text-align: center;
+    position: sticky;
+    top: 0;
+}
+header h1 {
+    margin: 0 0 0.5rem 0;
+    font-weight: 700;
+}
+#download-ics {
+    background: #fff;
+    color: #e60012;
+    border: none;
+    padding: 0.5rem 1rem;
+    font-size: 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+}
+.day {
+    margin: 1rem;
+    background: rgba(255,255,255,0.9);
+    border-radius: 8px;
+    padding: 1rem;
+}
+.event {
+    border-bottom: 1px solid #ccc;
+    padding: 0.5rem 0;
+}
+.event:last-child {
+    border-bottom: none;
+}
+.time {
+    font-weight: bold;
+    color: #e60012;
+}
+@media (min-width: 600px) {
+    .day {
+        margin: 1rem auto;
+        max-width: 600px;
+    }
+}


### PR DESCRIPTION
## Summary
- add GitHub Pages website in `docs/` folder
- style with Nintendo-inspired colors
- load `agenda.json` dynamically and render three day schedule
- provide button to download entire schedule as ICS file

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68828b37a56c83218832266f6cada261