### PR TITLE
Add mobile schedule site with .ics download

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,89 @@
+async function loadSchedule(){
+  const res = await fetch('agenda.json');
+  const data = await res.json();
+  const scheduleEl = document.getElementById('schedule');
+  const days = {
+    friday: 'Friday, July 25, 2025',
+    saturday: 'Saturday, July 26, 2025',
+    sunday: 'Sunday, July 27, 2025'
+  };
+  for(const key of Object.keys(days)){
+    const events = data[key];
+    const dayEl = document.createElement('section');
+    dayEl.className = 'day';
+    dayEl.innerHTML = `<h2>${days[key]}</h2>`;
+    events.forEach(evt => {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'event';
+      const imgSrc = evt.speakers && evt.speakers[0] ? evt.speakers[0].media : (evt.moderator ? evt.moderator.media : '');
+      const img = document.createElement('img');
+      if(imgSrc) img.src = imgSrc;
+      img.alt = '';
+      const details = document.createElement('div');
+      details.className = 'event-details';
+      const speakerNames = [];
+      if(evt.moderator) speakerNames.push(`Moderator: ${evt.moderator.name}`);
+      if(Array.isArray(evt.speakers)){
+        evt.speakers.forEach(s => speakerNames.push(s.name));
+      }
+      details.innerHTML = `<div class="event-time">${evt.time} &middot; ${evt.where}</div>
+        <h3>${evt.title}</h3>
+        <p>${speakerNames.join(', ')}</p>
+        ${evt.description ? `<p>${evt.description}</p>` : ''}`;
+      wrapper.appendChild(img);
+      wrapper.appendChild(details);
+      dayEl.appendChild(wrapper);
+    });
+    scheduleEl.appendChild(dayEl);
+  }
+  return data;
+}
+
+function to24(dateStr, timeStr){
+  const [t, ampm] = timeStr.split(' ');
+  let [h,m] = t.split(':').map(Number);
+  if(ampm === 'PM' && h !== 12) h += 12;
+  if(ampm === 'AM' && h === 12) h = 0;
+  const date = new Date(dateStr);
+  date.setHours(h,m,0,0);
+  return date;
+}
+
+function formatICS(d){
+  const pad=n=>String(n).padStart(2,'0');
+  return d.getFullYear()+pad(d.getMonth()+1)+pad(d.getDate())+'T'+pad(d.getHours())+pad(d.getMinutes())+'00';
+}
+
+async function downloadCalendar(){
+  const data = await loadSchedule();
+  const map = {friday:'2025-07-25', saturday:'2025-07-26', sunday:'2025-07-27'};
+  let ics = 'BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//Open Sauce//Schedule//EN\nCALSCALE:GREGORIAN\n';
+  for(const day of Object.keys(map)){
+    data[day].forEach(evt => {
+      const start = to24(map[day], evt.time);
+      const end = new Date(start.getTime() + (parseInt(evt.length||'0')*60000));
+      ics += 'BEGIN:VEVENT\n';
+      ics += 'DTSTART:'+formatICS(start)+'\n';
+      ics += 'DTEND:'+formatICS(end)+'\n';
+      ics += 'SUMMARY:'+evt.title.replace(/\n/g,' ')+'\n';
+      if(evt.where) ics += 'LOCATION:'+evt.where.replace(/\n/g,' ')+'\n';
+      if(evt.description) ics += 'DESCRIPTION:'+evt.description.replace(/\n/g,' ')+'\n';
+      ics += 'END:VEVENT\n';
+    });
+  }
+  ics += 'END:VCALENDAR';
+  const blob = new Blob([ics], {type:'text/calendar'});
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'open-sauce-schedule.ics';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+window.addEventListener('DOMContentLoaded', async () => {
+  await loadSchedule();
+  document.getElementById('downloadBtn').addEventListener('click', downloadCalendar);
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Open Sauce Schedule 2025</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<header class="hero">
+  <h1>Open Sauce 2025 Schedule</h1>
+  <button id="downloadBtn">Download Calendar</button>
+</header>
+<main id="schedule"></main>
+<script src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,56 @@
+body{
+  margin:0;
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height:1.4;
+  background:#fff;
+  color:#333;
+}
+.hero{
+  text-align:center;
+  padding:2rem 1rem;
+  background:linear-gradient(120deg,#000,#333);
+  color:#fff;
+}
+.hero h1{margin:0 0 1rem; font-size:2rem;}
+.hero button{
+  background:#007aff;
+  border:0;
+  color:#fff;
+  padding:.75rem 1.5rem;
+  border-radius:8px;
+  font-size:1rem;
+  cursor:pointer;
+}
+#schedule{padding:2rem 1rem; display:flex; flex-direction:column; gap:2rem; max-width:900px; margin:0 auto;}
+.day{
+  margin-bottom:2rem;
+}
+.day h2{
+  margin-bottom:1rem;
+  border-bottom:2px solid #eee;
+  padding-bottom:.5rem;
+}
+.event{
+  display:flex;
+  gap:1rem;
+  margin-bottom:1.5rem;
+  align-items:flex-start;
+  border-bottom:1px solid #eee;
+  padding-bottom:1rem;
+}
+.event img{
+  width:64px;
+  height:64px;
+  object-fit:cover;
+  border-radius:8px;
+}
+.event-details{
+  flex:1;
+}
+.event-time{
+  font-weight:bold;
+}
+@media (min-width:600px){
+  .event{gap:1.5rem;}
+  .event img{width:80px;height:80px;}
+}


### PR DESCRIPTION
## Summary
- build a simple web site for the schedule
- fetch agenda.json and render by day
- style page to be mobile friendly and mimic Apple style
- add Download Calendar button that generates an iCalendar file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6882dc56e3b483218abaa2c90591dbc7