### PR TITLE
Enhance hero section with video background

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -115,6 +115,19 @@ window.addEventListener('DOMContentLoaded', async () => {
         }
       });
     });
+
+    // hero fade and scale when scrolling into main content
+    gsap.to('.hero-content', {
+      opacity:0,
+      scale:0.9,
+      ease:'none',
+      scrollTrigger:{
+        trigger:'#schedule',
+        start:'top top',
+        end:'+=150',
+        scrub:true
+      }
+    });
   }
 
   // sticky header fading

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,8 +13,14 @@ layout: none
 </head>
 <body>
 <header class="hero">
-  <h1>Open Sauce 2025 Schedule</h1>
-  <button id="downloadBtn">Download Calendar</button>
+  <div class="video-wrapper">
+    <iframe src="https://www.youtube.com/embed/ZbRjDmBh9lc?autoplay=1&mute=1&controls=0&loop=1&start=73&playlist=ZbRjDmBh9lc&modestbranding=1" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
+  </div>
+  <div class="overlay"></div>
+  <div class="hero-content">
+    <h1>Open Sauce 2025 Schedule</h1>
+    <button id="downloadBtn">Download Calendar</button>
+  </div>
 </header>
 <main id="schedule"></main>
 <script src="app.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,7 @@ layout: none
 <body>
 <header class="hero">
   <div class="video-wrapper">
-    <iframe src="https://www.youtube.com/embed/ZbRjDmBh9lc?autoplay=1&mute=1&controls=0&loop=1&start=73&playlist=ZbRjDmBh9lc&modestbranding=1" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
+    <iframe src="https://www.youtube.com/embed/ZbRjDmBh9lc?autoplay=1&mute=1&controls=0&loop=1&playlist=ZbRjDmBh9lc&start=73&modestbranding=1&playsinline=1" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
   </div>
   <div class="overlay"></div>
   <div class="hero-content">

--- a/docs/style.css
+++ b/docs/style.css
@@ -2,27 +2,60 @@ body{
   margin:0;
   font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
   line-height:1.4;
-  background:#fff;
-  color:#333;
+  background:#FFFCF2;
+  color:#252422;
   scroll-behavior:smooth;
 }
+
 .hero{
+  position:fixed;
+  top:0;
+  left:0;
+  width:100%;
+  height:33vh;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  overflow:hidden;
+  color:#FFFCF2;
+}
+.video-wrapper{
+  position:absolute;
+  inset:0;
+  overflow:hidden;
+  z-index:0;
+}
+.video-wrapper iframe{
+  width:100%;
+  height:100%;
+  pointer-events:none;
+}
+.overlay{
+  position:absolute;
+  inset:0;
+  background:linear-gradient(to bottom, rgba(255,255,255,0) 0%, #252422 100%);
+  z-index:1;
+}
+.hero-content{
+  position:relative;
+  z-index:2;
   text-align:center;
   padding:2rem 1rem;
-  background:linear-gradient(120deg,#000,#333);
-  color:#fff;
 }
-.hero h1{margin:0 0 1rem; font-size:2rem;}
+.hero h1{margin:0 0 1rem;font-size:2rem;}
 .hero button{
-  background:#007aff;
+  background:#EB5E28;
   border:0;
-  color:#fff;
+  color:#FFFCF2;
   padding:.75rem 1.5rem;
   border-radius:8px;
   font-size:1rem;
   cursor:pointer;
-  transition:transform .2s;
+  transition:transform .2s, background .3s;
   will-change:transform;
+}
+.hero button:hover{
+  background:#d64c1f;
 }
 #schedule{
   padding:2rem 1rem;
@@ -30,7 +63,7 @@ body{
   flex-direction:column;
   gap:2rem;
   max-width:900px;
-  margin:0 auto;
+  margin:33vh auto 0;
   scroll-snap-type:y mandatory;
 }
 .day{

--- a/docs/style.css
+++ b/docs/style.css
@@ -18,6 +18,7 @@ body{
   justify-content:center;
   overflow:hidden;
   color:#FFFCF2;
+  z-index:-1;
 }
 .video-wrapper{
   position:absolute;
@@ -29,11 +30,12 @@ body{
   width:100%;
   height:100%;
   pointer-events:none;
+  object-fit:cover;
 }
 .overlay{
   position:absolute;
   inset:0;
-  background:linear-gradient(to bottom, rgba(255,255,255,0) 0%, #252422 100%);
+  background:linear-gradient(to bottom, rgba(37,36,34,0) 0%, rgba(37,36,34,0.85) 100%);
   z-index:1;
 }
 .hero-content{
@@ -75,7 +77,7 @@ body{
 }
 .day h2{
   margin-bottom:1rem;
-  border-bottom:2px solid #eee;
+  border-bottom:2px solid #CCC5B9;
   padding-bottom:.5rem;
   position:sticky;
   top:0;
@@ -92,7 +94,7 @@ body{
   gap:1rem;
   margin-bottom:1.5rem;
   align-items:flex-start;
-  border-bottom:1px solid #eee;
+  border-bottom:1px solid #CCC5B9;
   padding-bottom:1rem;
   opacity:0;
   transform:translateY(40px);


### PR DESCRIPTION
## Summary
- add YouTube-based hero with looping video
- restyle site with new color palette and fixed video header
- fade hero out with GSAP as schedule scrolls into view

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6882f21767188321b8ed3f6e93ca0bdf