### PR TITLE
Add responsive hero header

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -1,35 +1,40 @@
-async function loadSchedule(){
-  const res = await fetch('agenda.json');
+async function loadSchedule() {
+  const res = await fetch("agenda.json");
   const data = await res.json();
-  const scheduleEl = document.getElementById('schedule');
+  const scheduleEl = document.getElementById("schedule");
   const days = {
-    friday: 'Friday, July 25, 2025',
-    saturday: 'Saturday, July 26, 2025',
-    sunday: 'Sunday, July 27, 2025'
+    friday: "Friday, July 25, 2025",
+    saturday: "Saturday, July 26, 2025",
+    sunday: "Sunday, July 27, 2025",
   };
-  for(const key of Object.keys(days)){
+  for (const key of Object.keys(days)) {
     const events = data[key];
-    const dayEl = document.createElement('section');
-    dayEl.className = 'day';
+    const dayEl = document.createElement("section");
+    dayEl.className = "day";
     dayEl.innerHTML = `<h2>${days[key]}</h2>`;
-    events.forEach(evt => {
-      const wrapper = document.createElement('div');
-      wrapper.className = 'event';
-      const imgSrc = evt.speakers && evt.speakers[0] ? evt.speakers[0].media : (evt.moderator ? evt.moderator.media : '');
-      const img = document.createElement('img');
-      if(imgSrc) img.src = imgSrc;
-      img.alt = '';
-      const details = document.createElement('div');
-      details.className = 'event-details';
+    events.forEach((evt) => {
+      const wrapper = document.createElement("div");
+      wrapper.className = "event";
+      const imgSrc =
+        evt.speakers && evt.speakers[0]
+          ? evt.speakers[0].media
+          : evt.moderator
+            ? evt.moderator.media
+            : "";
+      const img = document.createElement("img");
+      if (imgSrc) img.src = imgSrc;
+      img.alt = "";
+      const details = document.createElement("div");
+      details.className = "event-details";
       const speakerNames = [];
-      if(evt.moderator) speakerNames.push(`Moderator: ${evt.moderator.name}`);
-      if(Array.isArray(evt.speakers)){
-        evt.speakers.forEach(s => speakerNames.push(s.name));
+      if (evt.moderator) speakerNames.push(`Moderator: ${evt.moderator.name}`);
+      if (Array.isArray(evt.speakers)) {
+        evt.speakers.forEach((s) => speakerNames.push(s.name));
       }
       details.innerHTML = `<div class="event-time">${evt.time} &middot; ${evt.where}</div>
         <h3>${evt.title}</h3>
-        <p>${speakerNames.join(', ')}</p>
-        ${evt.description ? `<p>${evt.description}</p>` : ''}`;
+        <p>${speakerNames.join(", ")}</p>
+        ${evt.description ? `<p>${evt.description}</p>` : ""}`;
       wrapper.appendChild(img);
       wrapper.appendChild(details);
       dayEl.appendChild(wrapper);
@@ -39,93 +44,111 @@ async function loadSchedule(){
   return data;
 }
 
-function to24(dateStr, timeStr){
-  const [t, ampm] = timeStr.split(' ');
-  let [h,m] = t.split(':').map(Number);
-  if(ampm === 'PM' && h !== 12) h += 12;
-  if(ampm === 'AM' && h === 12) h = 0;
+function to24(dateStr, timeStr) {
+  const [t, ampm] = timeStr.split(" ");
+  let [h, m] = t.split(":").map(Number);
+  if (ampm === "PM" && h !== 12) h += 12;
+  if (ampm === "AM" && h === 12) h = 0;
   const date = new Date(dateStr);
-  date.setHours(h,m,0,0);
+  date.setHours(h, m, 0, 0);
   return date;
 }
 
-function formatICS(d){
-  const pad=n=>String(n).padStart(2,'0');
-  return d.getFullYear()+pad(d.getMonth()+1)+pad(d.getDate())+'T'+pad(d.getHours())+pad(d.getMinutes())+'00';
+function formatICS(d) {
+  const pad = (n) => String(n).padStart(2, "0");
+  return (
+    d.getFullYear() +
+    pad(d.getMonth() + 1) +
+    pad(d.getDate()) +
+    "T" +
+    pad(d.getHours()) +
+    pad(d.getMinutes()) +
+    "00"
+  );
 }
 
-async function downloadCalendar(){
+async function downloadCalendar() {
   const data = await loadSchedule();
-  const map = {friday:'2025-07-25', saturday:'2025-07-26', sunday:'2025-07-27'};
-  let ics = 'BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//Open Sauce//Schedule//EN\nCALSCALE:GREGORIAN\n';
-  for(const day of Object.keys(map)){
-    data[day].forEach(evt => {
+  const map = {
+    friday: "2025-07-25",
+    saturday: "2025-07-26",
+    sunday: "2025-07-27",
+  };
+  let ics =
+    "BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//Open Sauce//Schedule//EN\nCALSCALE:GREGORIAN\n";
+  for (const day of Object.keys(map)) {
+    data[day].forEach((evt) => {
       const start = to24(map[day], evt.time);
-      const end = new Date(start.getTime() + (parseInt(evt.length||'0')*60000));
-      ics += 'BEGIN:VEVENT\n';
-      ics += 'DTSTART:'+formatICS(start)+'\n';
-      ics += 'DTEND:'+formatICS(end)+'\n';
-      ics += 'SUMMARY:'+evt.title.replace(/\n/g,' ')+'\n';
-      if(evt.where) ics += 'LOCATION:'+evt.where.replace(/\n/g,' ')+'\n';
-      if(evt.description) ics += 'DESCRIPTION:'+evt.description.replace(/\n/g,' ')+'\n';
-      ics += 'END:VEVENT\n';
+      const end = new Date(
+        start.getTime() + parseInt(evt.length || "0") * 60000,
+      );
+      ics += "BEGIN:VEVENT\n";
+      ics += "DTSTART:" + formatICS(start) + "\n";
+      ics += "DTEND:" + formatICS(end) + "\n";
+      ics += "SUMMARY:" + evt.title.replace(/\n/g, " ") + "\n";
+      if (evt.where) ics += "LOCATION:" + evt.where.replace(/\n/g, " ") + "\n";
+      if (evt.description)
+        ics += "DESCRIPTION:" + evt.description.replace(/\n/g, " ") + "\n";
+      ics += "END:VEVENT\n";
     });
   }
-  ics += 'END:VCALENDAR';
-  const blob = new Blob([ics], {type:'text/calendar'});
+  ics += "END:VCALENDAR";
+  const blob = new Blob([ics], { type: "text/calendar" });
   const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
+  const a = document.createElement("a");
   a.href = url;
-  a.download = 'open-sauce-schedule.ics';
+  a.download = "open-sauce-schedule.ics";
   document.body.appendChild(a);
   a.click();
   a.remove();
   URL.revokeObjectURL(url);
 }
 
-
-window.addEventListener('DOMContentLoaded', async () => {
+window.addEventListener("DOMContentLoaded", async () => {
   await loadSchedule();
-  document.getElementById('downloadBtn').addEventListener('click', downloadCalendar);
+  const btn = document.querySelector(".hero-cta");
+  btn.addEventListener("click", downloadCalendar);
 
   // magnetic hover effect
-  const btn = document.getElementById('downloadBtn');
-  btn.addEventListener('mousemove', e => {
+  btn.addEventListener("mousemove", (e) => {
     const r = btn.getBoundingClientRect();
-    const x = e.clientX - r.left - r.width/2;
-    const y = e.clientY - r.top - r.height/2;
-    gsap.to(btn, {x:x*0.3, y:y*0.3, duration:0.3, ease:'power2.out'});
+    const x = e.clientX - r.left - r.width / 2;
+    const y = e.clientY - r.top - r.height / 2;
+    gsap.to(btn, { x: x * 0.3, y: y * 0.3, duration: 0.3, ease: "power2.out" });
   });
-  btn.addEventListener('mouseleave', () => {
-    gsap.to(btn, {x:0, y:0, duration:0.4, ease:'power2.out'});
+  btn.addEventListener("mouseleave", () => {
+    gsap.to(btn, { x: 0, y: 0, duration: 0.4, ease: "power2.out" });
   });
 
   // GSAP scroll animations
-  if(window.gsap){
+  if (window.gsap) {
     gsap.registerPlugin(ScrollTrigger);
-    gsap.utils.toArray('.event').forEach(el => {
+    gsap.utils.toArray(".event").forEach((el) => {
       gsap.to(el, {
-        opacity:1,
-        y:0,
-        duration:0.6,
-        ease:'power1.out',
-        scrollTrigger:{
-          trigger:el,
-          start:'top 85%'
-        }
+        opacity: 1,
+        y: 0,
+        duration: 0.6,
+        ease: "power1.out",
+        scrollTrigger: {
+          trigger: el,
+          start: "top 85%",
+        },
       });
     });
   }
 
   // sticky header fading
-  const observer=new IntersectionObserver(entries=>{
-    entries.forEach(ent=>{
-      if(ent.intersectionRatio<1){
-        ent.target.dataset.stuck='true';
-      }else{
-        delete ent.target.dataset.stuck;
-      }
-    });
-  },{threshold:[1]});
-  document.querySelectorAll('.day h2').forEach(h=>observer.observe(h));
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((ent) => {
+        if (ent.intersectionRatio < 1) {
+          ent.target.dataset.stuck = "true";
+        } else {
+          delete ent.target.dataset.stuck;
+        }
+      });
+    },
+    { threshold: [1] },
+  );
+  document.querySelectorAll(".day h2").forEach((h) => observer.observe(h));
 });

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,22 +1,107 @@
 ---
 layout: none
 ---
-<!DOCTYPE html>
+
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Open Sauce Schedule 2025</title>
-  <link rel="stylesheet" href="style.css">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js"></script>
-</head>
-<body>
-<header class="hero">
-  <h1>Open Sauce 2025 Schedule</h1>
-  <button id="downloadBtn">Download Calendar</button>
-</header>
-<main id="schedule"></main>
-<script src="app.js"></script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Open Sauce Schedule 2025</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="style.css" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js"></script>
+    <style>
+      body {
+        margin: 0;
+        font-family: "Poppins", sans-serif;
+      }
+
+      .hero-header {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 80vh;
+        color: white;
+        background-image:
+          linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6)),
+          url("https://a.storyblok.com/f/188325/1024x683/bfe4f13b8b/alex-kotliarskyi-ourqhrte2im-unsplash-1024x683.jpg/m/filters:quality(75)?");
+        background-size: cover;
+        background-position: center center;
+      }
+
+      .hero-content {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        max-width: 800px;
+        padding: 20px;
+      }
+
+      .hero-logo {
+        width: 150px;
+        margin-bottom: 2rem;
+      }
+
+      .hero-title {
+        font-size: 3.5rem;
+        font-weight: 700;
+        margin-top: 0;
+        margin-bottom: 1rem;
+      }
+
+      .hero-subtitle {
+        font-size: 1.25rem;
+        font-weight: 400;
+        max-width: 600px;
+        margin-bottom: 2.5rem;
+      }
+
+      .hero-cta {
+        display: inline-block;
+        padding: 12px 28px;
+        border: 2px solid white;
+        border-radius: 5px;
+        color: white;
+        background-color: transparent;
+        text-decoration: none;
+        font-size: 1rem;
+        font-weight: 700;
+        transition:
+          background-color 0.3s ease,
+          color 0.3s ease;
+      }
+
+      .hero-cta:hover {
+        background-color: white;
+        color: black;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="hero-header">
+      <div class="hero-content">
+        <img
+          src="https://opensauce.com/wp-content/uploads/2023/02/OS-LOGO-W-Header.png"
+          alt="Open Sauce Logo"
+          class="hero-logo"
+        />
+        <h1 class="hero-title">Open Sauce 2025</h1>
+        <p class="hero-subtitle">
+          Join the world's premier open source conference. Connect, collaborate,
+          and create with the brightest minds in technology.
+        </p>
+        <a href="#" class="hero-cta">Download Calendar</a>
+      </div>
+    </header>
+    <main id="schedule"></main>
+    <script src="app.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- replace original header with responsive hero design
- load Poppins font and style hero section
- hook calendar download to the new CTA
- format files with Prettier

## Testing
- `npx prettier --check docs/index.html docs/app.js`

------
https://chatgpt.com/codex/tasks/task_b_688841fd4a8c8321bc625c233173d6d5