### PR TITLE
Add dynamic schedule section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -84,6 +84,14 @@ layout: none
         color: black;
       }
 
+      /* Override default width for schedule container */
+      #schedule {
+        max-width: none;
+        width: 100%;
+        margin: 0;
+        padding: 0;
+      }
+
       /* General Section Styling */
       .schedule-section {
         background-color: #1A1A1A;
@@ -282,15 +290,18 @@ layout: none
           </div>
         </div>
 
-        <a href="open-sauce-schedule.ics" class="primary-cta-button" download>Download Calendar</a>
+        <a href="#" id="download-calendar" class="primary-cta-button">Download Calendar</a>
       </section>
     </main>
     <script>
+      let scheduleData;
       document.addEventListener('DOMContentLoaded', async () => {
         const res = await fetch('agenda.json');
-        const data = await res.json();
+        scheduleData = await res.json();
         const container = document.querySelector('.schedule-scroll-container');
         const tabs = document.querySelectorAll('.tab-button');
+        const downloadBtn = document.getElementById('download-calendar');
+        const heroBtn = document.querySelector('.hero-cta');
 
         function createCard(evt, speaker) {
           if (!speaker || !speaker.name || !speaker.media) return null;
@@ -314,7 +325,7 @@ layout: none
 
         function displayDay(day) {
           container.innerHTML = '';
-          data[day].forEach(evt => {
+          scheduleData[day].forEach(evt => {
             if (Array.isArray(evt.speakers)) {
               evt.speakers.forEach(sp => {
                 const card = createCard(evt, sp);
@@ -333,6 +344,69 @@ layout: none
         });
 
         displayDay('friday');
+
+        function to24(dateStr, timeStr) {
+          const [t, ampm] = timeStr.split(' ');
+          let [h, m] = t.split(':').map(Number);
+          if (ampm === 'PM' && h !== 12) h += 12;
+          if (ampm === 'AM' && h === 12) h = 0;
+          const d = new Date(dateStr);
+          d.setHours(h, m, 0, 0);
+          return d;
+        }
+
+        function formatICS(d) {
+          const pad = n => String(n).padStart(2, '0');
+          return (
+            d.getFullYear() +
+            pad(d.getMonth() + 1) +
+            pad(d.getDate()) +
+            'T' +
+            pad(d.getHours()) +
+            pad(d.getMinutes()) +
+            '00'
+          );
+        }
+
+        function downloadCalendar() {
+          const map = {
+            friday: '2025-07-25',
+            saturday: '2025-07-26',
+            sunday: '2025-07-27'
+          };
+          let ics = 'BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//Open Sauce//Schedule//EN\nCALSCALE:GREGORIAN\n';
+          for (const day of Object.keys(map)) {
+            scheduleData[day].forEach(evt => {
+              const start = to24(map[day], evt.time);
+              const end = new Date(start.getTime() + parseInt(evt.length || '0') * 60000);
+              ics += 'BEGIN:VEVENT\n';
+              ics += 'DTSTART:' + formatICS(start) + '\n';
+              ics += 'DTEND:' + formatICS(end) + '\n';
+              ics += 'SUMMARY:' + evt.title.replace(/\n/g, ' ') + '\n';
+              if (evt.where) ics += 'LOCATION:' + evt.where.replace(/\n/g, ' ') + '\n';
+              if (evt.description) ics += 'DESCRIPTION:' + evt.description.replace(/\n/g, ' ') + '\n';
+              ics += 'END:VEVENT\n';
+            });
+          }
+          ics += 'END:VCALENDAR';
+          const blob = new Blob([ics], { type: 'text/calendar' });
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = 'open-sauce-schedule.ics';
+          document.body.appendChild(a);
+          a.click();
+          a.remove();
+          URL.revokeObjectURL(url);
+        }
+
+        [downloadBtn, heroBtn].forEach(btn => {
+          if (!btn) return;
+          btn.addEventListener('click', e => {
+            e.preventDefault();
+            downloadCalendar();
+          });
+        });
       });
     </script>
   </body>


### PR DESCRIPTION
## Summary
- implement new Event Schedule section in docs/index.html
- add required CSS styles
- populate cards dynamically using `agenda.json`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68884f8147808321a96cca7e902b2e3c