### PR TITLE
Fix Poppins font application

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1,6 +1,9 @@
+*{
+  box-sizing:border-box;
+}
 body{
   margin:0;
-  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  font-family:'Poppins', sans-serif;
   line-height:1.4;
   background:#fff;
   color:#333;


### PR DESCRIPTION
## Summary
- set `box-sizing: border-box` globally
- apply Poppins font to the entire site

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6888f62785dc8321b8d5fc1e8227a544