### PR TITLE
Improve horizontal schedule scroll ending

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -511,6 +511,7 @@ layout: none
           });
           updateTrackWidth();
           setUniformHeight();
+          updateWrapperHeight();
           track.style.transform = 'translateX(0)';
           if (day) {
             tabs.forEach(b => b.classList.toggle('active', b.dataset.day === day));
@@ -538,8 +539,9 @@ layout: none
         let maxScroll = 0;
 
         function updateWrapperHeight() {
-          maxScroll = track.scrollWidth - window.innerWidth;
-          wrapper.style.height = maxScroll + window.innerHeight + 'px';
+          const visible = Array.from(track.children).filter(c => c.style.display !== 'none');
+          maxScroll = Math.max(0, (visible.length - 1) * (cardWidth + gap));
+          wrapper.style.height = Math.ceil(maxScroll + window.innerHeight) + 'px';
         }
 
         updateWrapperHeight();


### PR DESCRIPTION
## Summary
- refine wrapper height calculation so last card ends centered
- recalc scroll range whenever the day filter changes

## Testing
- `tidy -e docs/index.html`

------
https://chatgpt.com/codex/tasks/task_b_68892d68778c832186911117f814a4c3