### PR TITLE
Fix schedule overscroll on filter

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -511,6 +511,7 @@ layout: none
           });
           updateTrackWidth();
           setUniformHeight();
+          updateWrapperHeight();
           track.style.transform = 'translateX(0)';
           if (day) {
             tabs.forEach(b => b.classList.toggle('active', b.dataset.day === day));


### PR DESCRIPTION
## Summary
- adjust schedule layout for filtered view
- ensure wrapper height matches track width when filters are applied

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_688abb06c504832184c46162485105ff