### PR TITLE
Fix scroll logic for track wrapper

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -511,6 +511,7 @@ layout: none
           });
           updateTrackWidth();
           setUniformHeight();
+          updateWrapperHeight();
           track.style.transform = 'translateX(0)';
           if (day) {
             tabs.forEach(b => b.classList.toggle('active', b.dataset.day === day));
@@ -538,7 +539,7 @@ layout: none
         let maxScroll = 0;
 
         function updateWrapperHeight() {
-          maxScroll = track.scrollWidth - window.innerWidth;
+          maxScroll = Math.max(track.scrollWidth - wrapper.clientWidth, 0);
           wrapper.style.height = maxScroll + window.innerHeight + 'px';
         }
 
@@ -552,9 +553,11 @@ layout: none
         function onScroll() {
           const rect = wrapper.getBoundingClientRect();
           const progress = Math.min(Math.max(-rect.top, 0), maxScroll);
-          requestAnimationFrame(() => {
-            track.style.transform = `translateX(-${progress}px)`;
-          });
+          if (progress >= maxScroll) {
+            track.style.transform = `translateX(-${maxScroll}px)`;
+            return; // final card locked; vertical scroll resumes
+          }
+          track.style.transform = `translateX(-${progress}px)`;
         }
 
         window.addEventListener('scroll', onScroll);


### PR DESCRIPTION
## Summary
- adjust wrapper height logic so width uses `wrapper.clientWidth`
- refresh wrapper height when filtering cards
- halt horizontal motion when scrolling past the last card

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_b_688abd5685b48321962258bc1407a20e